### PR TITLE
bootstrapper drops config options

### DIFF
--- a/lib/broadway/bootstrapper.js
+++ b/lib/broadway/bootstrapper.js
@@ -16,15 +16,7 @@ var broadway = require('../broadway');
 //
 exports.bootstrap = function (app) {
   app.options['config']        = app.options['config'] || {};
-<<<<<<< HEAD
   // app.options['config'].init   = false;
-=======
-<<<<<<< HEAD
-  // app.options['config'].init   = false;
-=======
-  app.options['config'].init   = false;
->>>>>>> 81c07b2b0f0763e38344fa511ff82854cc107aff
->>>>>>> 888ca34b22e1cd86865fa95e9f99830be8b740fe
   app.use(broadway.plugins.config, app.options['config']);
 };
 


### PR DESCRIPTION
``` javascript
exports.bootstrap = function (app) {
  app.options['config']        = app.options['config'] || {};
  app.options['config'].init   = false;
  app.use(broadway.plugins.config);
};
```

config options you may have passed to `new broadway.App` are dropped because `App.prototype.use` overwrites `options[<plugin name>]` with an empty object when no options argument is included ...
