### PR TITLE
When plugins are missing a name, some plugins simply don't load

### DIFF
--- a/lib/broadway/app.js
+++ b/lib/broadway/app.js
@@ -131,6 +131,9 @@ App.prototype.use = function (plugin, options, callback) {
 
   var name = plugin.name,
       self = this;
+     
+  // If the plugin doesn't have a name, use itself as an identifier for the plugins hash.
+  if (name == null) name = plugin;
       
   if (this.plugins[name] && this.plugins[name].detach) {
     this.plugins[name].detach(this);


### PR DESCRIPTION
... leading to confusion, example:

app.use(require('./unnamed-plugin1'));
app.use(require('./unnamed-plugin2'));
app.init();
// Only unnamed-plugin2 will load in this case.

I opted to use the plugin itself as the identifier if missing a name, as name seems like it should be optional. Alternatively, throw an exception so the developer can fix it.
