### PR TITLE
[fix] default transport logger gets its level set to options.level

### DIFF
--- a/lib/broadway/plugins/log.js
+++ b/lib/broadway/plugins/log.js
@@ -56,6 +56,11 @@ log.attach = function (options) {
   this.log = new winston.Container(options);
   this.log.namespaces = namespaces;
   this.log.get('default').extend(this.log);
+
+  //
+  // Set the default console loglevel to options.level
+  //
+  this.log.get('default').transports.console.level = options.level || 'info';
   
   Object.defineProperty(this.log, 'logAll', {
     get: function () {


### PR DESCRIPTION
I'm not sure this is the _best_ way to fix it, but it seems to work. This would close gh-20 and nodejitsu/jitsu#159 .
