### PR TITLE
upgrade eventemitter2 to fix solaris issue (should use 0.4.x instead?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "colors": "0.6.0-1",
     "cliff": "0.1.7",
-    "eventemitter2": "0.4.8",
+    "eventemitter2": "0.4.9",
     "nconf": "0.5.1",
     "optimist": "0.3.1",
     "winston": "0.5.10",


### PR DESCRIPTION
Fixes issue from here:
https://github.com/hij1nx/EventEmitter2/issues/58
