### PR TITLE
Make synchronous use calls chainable

### DIFF
--- a/lib/broadway/app.js
+++ b/lib/broadway/app.js
@@ -170,7 +170,12 @@ App.prototype.use = function (plugin, options, callback) {
   // not false. This allows for some plugins to be lazy-loaded
   //
   if (options.init === false) {
-    return callback && callback();
+    if (callback) {
+      return callback();
+    } else {
+      // Make synchronous `use` calls chainable.
+      return this;
+    }
   }
 
   if (!this.initialized) {


### PR DESCRIPTION
It would be nice to be able to write something like:

```js
app
  .use(plugin1)
  .use(plugin2)
  ...
```
This simple fix enables this.