### PR TITLE
Updating dependencies, Winston from version 0.6.2 to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "cliff": "0.1.8",
-    "eventemitter2": "0.4.11",
+    "eventemitter2": "0.4.12",
     "nconf": "0.6.7",
-    "winston": "0.6.2",
-    "utile": "0.1.7"
+    "winston": "0.7.2",
+    "utile": "0.2.0"
   },
   "devDependencies": {
     "codesurgeon": "0.3.x",


### PR DESCRIPTION
I would very much like Broadway to use the latest version of Winston.
