### PR TITLE
Disambiguate "preboot" interceptor

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,15 +67,9 @@ App.prototype.start = function start(options, callback) {
 
   mixin(this.options, options, true);
 
-  this.perform('preboot', this, this.options, function (booted) {
-    booted();
-  }, function (err) {
-    if (err) { return callback(err); }
-
-    this.perform('start', this, this.options, function (next) {
-      self._listen(next);
-    }, callback);
-  });
+  this.perform('setup', this, this.options, function (done) {
+    this.perform('start', this, this.options, this._listen, done);
+  }, callback);
 };
 
 /*

--- a/test/unit.tests.js
+++ b/test/unit.tests.js
@@ -102,13 +102,13 @@ describe('broadway', function () {
 
     it('should error if a `.before("preboot")` errors', function (done) {
       var app = new App({ http: 8090 });
-      app.before('preboot', function (app, options, callback) {
-        return callback(new Error('Bad preboot'));
+      app.before('setup', function (app, options, callback) {
+        return callback(new Error('Bad setup preboot'));
       });
 
       app.start(function (err) {
         assert.ok(err);
-        assert.equal(err.message, 'Bad preboot');
+        assert.equal(err.message, 'Bad setup preboot');
         done();
       });
     });


### PR DESCRIPTION
Rename "preboot" interceptor to "setup" to remove ambiguity with preboot functions themselves.